### PR TITLE
chore: change name of class ReceiptIline add admin

### DIFF
--- a/core/billing/admin.py
+++ b/core/billing/admin.py
@@ -10,10 +10,28 @@ class ReceiptItemInline(admin.TabularInline):
 
 class ReceiptAdmin(admin.ModelAdmin):
     inlines = [ReceiptItemInline]
-    list_display = ('name', 'email', 'address', 'vat_identification_country', 'vat_identification_number',
-                    'total_amount_exclude_vat', 'total_amount_include_vat', 'receipt_link', 'receipt_document_id')
-    search_fields = ('name', 'email', 'address', 'vat_identification_country', 'vat_identification_number',
-                     'total_amount_exclude_vat', 'total_amount_include_vat', 'receipt_link', 'receipt_document_id')
-    
+    list_display = (
+        "name",
+        "email",
+        "address",
+        "vat_identification_country",
+        "vat_identification_number",
+        "total_amount_exclude_vat",
+        "total_amount_include_vat",
+        "receipt_link",
+        "receipt_document_id",
+    )
+    search_fields = (
+        "name",
+        "email",
+        "address",
+        "vat_identification_country",
+        "vat_identification_number",
+        "total_amount_exclude_vat",
+        "total_amount_include_vat",
+        "receipt_link",
+        "receipt_document_id",
+    )
+
 
 admin.site.register(Receipt, ReceiptAdmin)

--- a/core/billing/factories.py
+++ b/core/billing/factories.py
@@ -2,7 +2,7 @@ from decimal import Decimal
 
 import factory
 
-from core.billing.models import Receipt, ReceiptLine
+from core.billing.models import Receipt, ReceiptItem
 
 
 class ReceiptFactory(factory.django.DjangoModelFactory):
@@ -22,9 +22,9 @@ class ReceiptFactory(factory.django.DjangoModelFactory):
     receipt_document_id = factory.Faker("uuid4")
 
 
-class ReceiptLineFactory(factory.django.DjangoModelFactory):
+class ReceiptItemFactory(factory.django.DjangoModelFactory):
     class Meta:
-        model = ReceiptLine
+        model = ReceiptItem
 
     receipt = factory.SubFactory(ReceiptFactory)
     description = factory.Faker("sentence")

--- a/core/billing/models.py
+++ b/core/billing/models.py
@@ -40,8 +40,6 @@ class ReceiptItem(BaseModel):
 
     def __str__(self):
         return self.description
-    
+
     class Meta:
-        constraints = [
-            models.UniqueConstraint(fields=['receipt'], name='unique_receipt_item')
-        ]
+        constraints = [models.UniqueConstraint(fields=["receipt"], name="unique_receipt_item")]

--- a/core/billing/tests/test_receipts.py
+++ b/core/billing/tests/test_receipts.py
@@ -1,10 +1,12 @@
+from decimal import Decimal
+from django.db import IntegrityError
 from django.test import TestCase
 
-from core.billing.factories import ReceiptFactory, ReceiptLineFactory
-from core.billing.models import Receipt, ReceiptLine
+from core.billing.factories import ReceiptFactory, ReceiptItemFactory
+from core.billing.models import Receipt, ReceiptItem
 
 
-class ReceiptModelTestCase(TestCase):
+class ReceiptTest(TestCase):
     """
     Test case for the Receipt model.
     """
@@ -53,50 +55,94 @@ class ReceiptModelTestCase(TestCase):
         self.assertEqual(receipt, retrieved_receipt)
 
 
-class ReceiptLineModelTestCase(TestCase):
+class ReceiptItemTest(TestCase):
     """
-    Test case for the ReceiptLine model.
+    Test case for the ReceiptItem model.
     """
 
-    def test_receipt_line_creation(self):
+    def test_receipt_item_creation(self):
         """
-        Test if a ReceiptLine instance can be created.
+        Test if a ReceiptItem instance can be created.
         """
-        receipt_line = ReceiptLineFactory()
-        self.assertIsInstance(receipt_line, ReceiptLine)
+        receipt_line = ReceiptItemFactory()
+        self.assertIsInstance(receipt_line, ReceiptItem)
 
-    def test_receipt_line_str_representation(self):
+    def test_receipt_item_str_representation(self):
         """
-        Test the string representation of a ReceiptLine instance.
+        Test the string representation of a ReceiptItem instance.
         """
-        receipt_line = ReceiptLineFactory(description="Product A")
+        receipt_line = ReceiptItemFactory(description="Product A")
         self.assertEqual(str(receipt_line), "Product A")
 
-    def test_receipt_line_update(self):
+    def test_receipt_item_update(self):
         """
-        Test updating the description of a ReceiptLine instance.
+        Test updating the description of a ReceiptItem instance.
         """
-        receipt_line = ReceiptLineFactory(description="Initial Description")
+        receipt_line = ReceiptItemFactory(description="Initial Description")
         new_description = "Updated Description"
         receipt_line.description = new_description
         receipt_line.save()
-        updated_receipt_line = ReceiptLine.objects.get(pk=receipt_line.pk)
+        updated_receipt_line = ReceiptItem.objects.get(pk=receipt_line.pk)
         self.assertEqual(updated_receipt_line.description, new_description)
 
-    def test_receipt_line_delete(self):
+    def test_receipt_item_delete(self):
         """
-        Test deleting a ReceiptLine instance.
+        Test deleting a ReceiptItem instance.
         """
-        receipt_line = ReceiptLineFactory()
+        receipt_line = ReceiptItemFactory()
         receipt_line_pk = receipt_line.pk
         receipt_line.delete()
-        with self.assertRaises(ReceiptLine.DoesNotExist):
-            ReceiptLine.objects.get(pk=receipt_line_pk)
+        with self.assertRaises(ReceiptItem.DoesNotExist):
+            ReceiptItem.objects.get(pk=receipt_line_pk)
 
-    def test_receipt_line_read(self):
+    def test_receipt_item_read(self):
         """
-        Test reading a ReceiptLine instance from the database.
+        Test reading a ReceiptItem instance from the database.
         """
-        receipt_line = ReceiptLineFactory()
-        retrieved_receipt_line = ReceiptLine.objects.get(pk=receipt_line.pk)
+        receipt_line = ReceiptItemFactory()
+        retrieved_receipt_line = ReceiptItem.objects.get(pk=receipt_line.pk)
         self.assertEqual(receipt_line, retrieved_receipt_line)
+
+    def test_unique_receipt_item_constraint(self):
+        """
+        Test that a `ReceiptItem` object cannot be associated with more than one `Receipt`.
+
+        This test creates a `Receipt` object and associates it with a `ReceiptItem` object. It then attempts to create
+        another `ReceiptItem` object with the same `Receipt`, which should raise an `IntegrityError` due to the
+        `UniqueConstraint` on the `ReceiptItem` model. We use the `assertRaises` method to check that the `IntegrityError`
+        is raised when attempting to create the new `ReceiptItem` object.
+        """
+        receipt = ReceiptFactory(
+            name="John Doe",
+            email="johndoe@example.com",
+            address="123 Main St",
+            vat_identification_country="US",
+            vat_identification_number="123456789",
+            total_amount_exclude_vat=Decimal("100.00"),
+            total_amount_include_vat=Decimal("110.00"),
+            receipt_link="https://example.com/receipt",
+            receipt_document_id="123456789",
+        )
+        ReceiptItemFactory(
+            receipt=receipt,
+            description="Item 1",
+            quantity=2,
+            vat_tax=Decimal("10.00"),
+            amount_exclude_vat=Decimal("50.00"),
+            amount_include_vat=Decimal("55.00"),
+            organization_code="ORG1",
+            course_code="COURSE1",
+            course_id="123456",
+        )
+        with self.assertRaises(IntegrityError):
+            ReceiptItemFactory(
+                receipt=receipt,
+                description="Item 2",
+                quantity=1,
+                vat_tax=Decimal("5.00"),
+                amount_exclude_vat=Decimal("25.00"),
+                amount_include_vat=Decimal("27.50"),
+                organization_code="ORG2",
+                course_code="COURSE2",
+                course_id="654321",
+            )

--- a/nau_financial_manager/settings.py
+++ b/nau_financial_manager/settings.py
@@ -28,7 +28,7 @@ DJANGO_APPS = [
     "django.contrib.sessions",
     "django.contrib.messages",
     "django.contrib.staticfiles",
-]   
+]
 
 THIRD_PARTY_APPS = [
     "safedelete",
@@ -42,9 +42,9 @@ THIRD_PARTY_APPS = [
 ]
 
 LOCAL_APPS = [
-   "core.billing",
-   "core.organization",
-   "core.shared_revenue",
+    "core.billing",
+    "core.organization",
+    "core.shared_revenue",
 ]
 
 INSTALLED_APPS = [*DJANGO_APPS, *THIRD_PARTY_APPS, *LOCAL_APPS]
@@ -57,7 +57,7 @@ MIDDLEWARE = [
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
-    "auditlog.middleware.AuditlogMiddleware"
+    "auditlog.middleware.AuditlogMiddleware",
 ]
 
 ROOT_URLCONF = "nau_financial_manager.urls"

--- a/nau_financial_manager/urls.py
+++ b/nau_financial_manager/urls.py
@@ -21,7 +21,7 @@ from drf_spectacular.views import SpectacularAPIView, SpectacularRedocView, Spec
 urlpatterns = [
     path("admin/", admin.site.urls),
     path("api-auth/", include("rest_framework.urls")),
-    path('api/schema/', SpectacularAPIView.as_view(), name='schema'),
-    path("api/docs/", SpectacularSwaggerView.as_view(url_name='schema'), name='swagger-ui'),
-    path("api/redocs/", SpectacularRedocView.as_view(url_name='schema'), name='redoc'),   
+    path("api/schema/", SpectacularAPIView.as_view(), name="schema"),
+    path("api/docs/", SpectacularSwaggerView.as_view(url_name="schema"), name="swagger-ui"),
+    path("api/redocs/", SpectacularRedocView.as_view(url_name="schema"), name="redoc"),
 ]


### PR DESCRIPTION
This PR adds Django admin area for Receipt on module Billing, change name of ReceitpLine to ReceiptItem and add a constraint to validate one item for each receipt