### PR TITLE
Check that a revenue configuration doesn't exceed 100% #164

### DIFF
--- a/apps/shared_revenue/models.py
+++ b/apps/shared_revenue/models.py
@@ -146,7 +146,7 @@ class RevenueConfiguration(BaseModel):
 
             assert percentages <= 1
         except Exception:
-            raise ValidationError("The partner percentage exceed 100%")
+            raise ValidationError("The partner percentage exceeds 100%")
 
     def validate_instance(self) -> None:
         try:


### PR DESCRIPTION
This PR includes `partner_percentage` amount validation in `RevenueConfiguration`.