### PR TITLE
No empty files on Django command that exports split for all organizations #219

### DIFF
--- a/apps/shared_revenue/management/commands/export_split_revenue.py
+++ b/apps/shared_revenue/management/commands/export_split_revenue.py
@@ -54,7 +54,7 @@ class Command(BaseCommand):
                 **kwargs,
             )
             finish = time.time() - start
-            self.stdout.write("\n-----FILE GENERATED SUCCESSFULLY-----\n")
+            self.stdout.write("\n-----FILE GENERATION EXECUTED SUCCESSFULLY-----\n")
             self.stdout.write(f"\nThe time to the file export was {finish}\n")
         except Exception as e:
             raise CommandError(f"\n-----AN ERROR HAS BEEN RAISED RUNNING THE FILE EXPORT: {e}")

--- a/apps/shared_revenue/services/split_export.py
+++ b/apps/shared_revenue/services/split_export.py
@@ -1,3 +1,4 @@
+import logging
 from datetime import datetime
 from typing import Dict, List
 
@@ -56,9 +57,11 @@ class SplitExportService:
             if not len(split_sheets[0]) == 0:
                 file_name: str = self._generate_file_name(optional=kwargs)
                 FileGenerator().generate_xlsx(file_name=file_name, sheets=split_sheets)
-            else:
-                print(
-                    f"\nNo data available to generate file using the parameters:\nstart_date: {start_date}\nend_date: {end_date}\noptions: {kwargs}"
-                )
+
+                return
+
+            logging.getLogger("nau_financial_manager").warning(
+                f"\nNo data available to generate file using the parameters:\nstart_date: {start_date}\nend_date: {end_date}\noptions: {kwargs}"
+            )
         except Exception as e:
             raise e

--- a/apps/shared_revenue/services/split_export.py
+++ b/apps/shared_revenue/services/split_export.py
@@ -53,7 +53,12 @@ class SplitExportService:
                 start_date=start_date,
                 end_date=end_date,
             ).execute_split_steps(**kwargs)
-            file_name: str = self._generate_file_name(optional=kwargs)
-            FileGenerator().generate_xlsx(file_name=file_name, sheets=split_sheets)
+            if not len(split_sheets[0]) == 0:
+                file_name: str = self._generate_file_name(optional=kwargs)
+                FileGenerator().generate_xlsx(file_name=file_name, sheets=split_sheets)
+            else:
+                print(
+                    f"\nNo data available to generate file using the parameters:\nstart_date: {start_date}\nend_date: {end_date}\noptions: {kwargs}"
+                )
         except Exception as e:
             raise e

--- a/nau_financial_manager/settings.py
+++ b/nau_financial_manager/settings.py
@@ -225,20 +225,24 @@ LOGGING = CONFIG.get(
         "version": 1,
         "disable_existing_loggers": False,
         "handlers": {
-            "console": {
+            "error": {
                 "level": "ERROR",
+                "class": "logging.StreamHandler",
+            },
+            "warning": {
+                "level": "WARNING",
                 "class": "logging.StreamHandler",
             },
         },
         "loggers": {
             "django": {
-                "handlers": ["console"],
+                "handlers": ["error", "warning"],
                 "level": "ERROR",
                 "propagate": True,
             },
             "nau_financial_manager": {
-                "handlers": ["console"],
-                "level": "ERROR",
+                "handlers": ["error", "warning"],
+                "level": 1,
                 "propagate": True,
             },
         },


### PR DESCRIPTION
This PR includes the condition to not generate empty files when it is exporting the split revenue, resolve #219.