### PR TITLE
Create a division of install packages with poetry dev vs prod

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -140,10 +140,15 @@ install-poetry: ## Install Poetry
 	@curl -sSL https://install.python-poetry.org | python -
 .PHONY: install-poetry
 
-install-packages: ## Install project dependencies
+install-packages: ## Install project dependencies without dev dependencies
+	@echo "Installing project dependencies..."
+	@$(POETRY) install --only main
+.PHONY: install-packages
+
+install-packages-dev: ## Install project dependencies with dev dependencies
 	@echo "Installing project dependencies..."
 	@$(POETRY) install
-.PHONY: install-packages
+.PHONY: install-packages-dev
 
 logs: ## display docker app logs (follow mode)
 	@$(LOGS_DOCKER_DEV) -f nau-financial-app

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,11 +15,6 @@ license="AGPL-3.0-or-later"
 [tool.poetry.dependencies]
 python = "^3.10.2"
 django = "^4.2.4"
-pre-commit = "^3.3.3"
-black = "^23.7.0"
-flake8 = "^6.1.0"
-factory-boy = "^3.3.0"
-pytest-django = "^4.5.2"
 django-safedelete = "^1.3.2"
 unidecode = "^1.3.6"
 djangorestframework = "^3.14.0"
@@ -39,6 +34,14 @@ django-celery-results = "2.3.1"
 django-storages = "^1.14.2"
 boto3 = "^1.33.4"
 gunicorn = "21.2.0"
+factory-boy = "^3.3.0"
+pytest-django = "^4.5.2"
+
+[tool.poetry.dev-dependencies]
+pre-commit = "^3.3.3"
+black = "^23.7.0"
+flake8 = "^6.1.0"
+
 
 [build-system]
 requires = ["poetry-core"]


### PR DESCRIPTION
This PR adds poetry option to install prod vs dev using --only main and make default install with this option Closed #206 