### PR TITLE
fix: nginx auto discovers a new app instance

### DIFF
--- a/docker/files/etc/nginx/conf.d/default.conf
+++ b/docker/files/etc/nginx/conf.d/default.conf
@@ -4,6 +4,11 @@ server {
     server_name localhost;
     charset utf-8;
 
+    # Use docker DNS resolver with a limited DNS valid time.
+    # This creates something like a discover mechanism.
+    # If the application service is redeployed the nginx service would discover this change automatically.
+    resolver 127.0.0.11 valid=10s;
+
     location ~ ^/static/(?P<file>.*) {
         root /nau/nau-financial-manager/static;
         try_files /$file @proxy_app;


### PR DESCRIPTION
When local developing if the application restart, the nginx wasn't autodiscovering the new instance of the app container. With a small line of nginx configuration the nginx uses the internal docker DNS with a short amout of valid time.