### PR TITLE
fix: discount integration to sage x3

### DIFF
--- a/apps/billing/services/processor_service.py
+++ b/apps/billing/services/processor_service.py
@@ -60,7 +60,7 @@ class SageX3Processor(TransactionProcessorInterface):
                 <FLD NAME="QTY">{item.quantity}</FLD>
                 <FLD NAME="STU">UN</FLD>
                 <FLD NAME="GROPRI">{item.unit_price_excl_vat}</FLD>
-                <FLD NAME="DISCRGVAL1">{item.discount}</FLD>
+                <FLD NAME="DISCRGVAL1">{item.discount * 100}</FLD>
                 <FLD NAME="VACITM1">{self.__vacitm1}</FLD>
             </LIN>
             """


### PR DESCRIPTION
The discount on Sage X3 is an integer that represents a percentage. Inside the financial manager is a decimal with 2 decimal places.