### PR TITLE
Multiple changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,8 +11,8 @@ else
 APP_DOCKER_COMMAND='gunicorn --workers 3 -c /usr/local/etc/gunicorn/app.py nau_financial_manager.wsgi:application'
 endif
 # or use in future the 'pytest' directly
-TEST_CMD = $(POETRY_RUN) python manage.py test --settings=nau_financial_manager.test
-TEST_MYSQL_CMD = $(POETRY_RUN) python manage.py test --settings=nau_financial_manager.test_mysql
+TEST_CMD = $(POETRY_RUN) pytest --ds=nau_financial_manager.test
+TEST_MYSQL_CMD = $(POETRY_RUN) pytest --ds=nau_financial_manager.test_mysql
 # TEST_CMD = $(POETRY_RUN) pytest
 LINT_CMD = $(POETRY_RUN) black .
 PRE_COMMIT = $(POETRY_RUN) pre-commit run --all-files

--- a/apps/billing/services/financial_processor_service.py
+++ b/apps/billing/services/financial_processor_service.py
@@ -14,8 +14,14 @@ class TransactionProcessorInterface:
         self.transaction = transaction
 
     def send_transaction_to_processor(self) -> dict:
+        """
+        This method sends the transaction to the processor.
+        """
         raise Exception("This method needs to be implemented")
 
     @property
     def data(self):
+        """
+        Generates the request data from the transaction, as expected for the service.
+        """
         raise Exception("This method needs to be implemented")

--- a/apps/billing/services/processor_service.py
+++ b/apps/billing/services/processor_service.py
@@ -24,6 +24,7 @@ class SageX3Processor(TransactionProcessorInterface):
         self.__vacbpr = getattr(settings, "GEOGRAPHIC_ACTIVITY_VACBPR_FIELD")
         self.__user_processor_auth = getattr(settings, "USER_PROCESSOR_AUTH")
         self.__user_processor_password = getattr(settings, "USER_PROCESSOR_PASSWORD")
+        self.__data = None
 
     def send_transaction_to_processor(self) -> dict:
         """
@@ -66,6 +67,17 @@ class SageX3Processor(TransactionProcessorInterface):
 
     @property
     def data(self) -> str:
+        """
+        This method generates the request data as xml text from a transaction,
+        as expected for the `Sage X3` service.
+
+        It uses memoization to prevent the generation of data multiple times unnecessary.
+        """
+        if not self.__data:
+            self.__data = self.__generate_data()
+        return self.__data
+
+    def __generate_data(self) -> str:
         """
         This method generates the request data as xml text from a transaction,
         as expected for the `Sage X3` service.
@@ -149,5 +161,5 @@ class SageX3Processor(TransactionProcessorInterface):
             </soapenv:Body>
         </soapenv:Envelope>
         """
-
         return data
+

--- a/apps/billing/services/processor_service.py
+++ b/apps/billing/services/processor_service.py
@@ -162,4 +162,3 @@ class SageX3Processor(TransactionProcessorInterface):
         </soapenv:Envelope>
         """
         return data
-

--- a/apps/billing/services/transaction_service.py
+++ b/apps/billing/services/transaction_service.py
@@ -115,8 +115,7 @@ class TransactionService:
             exception_stack_trace = traceback.format_exc()
             self.__save_transaction_xml(
                 informations={
-                    "output_xml": f"An exception has been raised when sending data to processor, exception message={e} stacktrace={exception_stack_trace}",
-                    "error_messages": exception_stack_trace,
+                    "error_messages": f"An exception has been raised when sending data to processor, exception message={e} stacktrace={exception_stack_trace}",
                     "status": SageX3TransactionInformation.FAILED,
                 },
                 transaction=self.transaction,

--- a/apps/billing/services/transaction_service.py
+++ b/apps/billing/services/transaction_service.py
@@ -38,11 +38,13 @@ class TransactionService:
         this process, it prints the exception message.
         """
         try:
+            transaction.refresh_from_db()
             obj, created = SageX3TransactionInformation.objects.get_or_create(
                 transaction=transaction, defaults={**informations}
             )
             if not created:
-                obj.retries += 1
+                if informations["status"] == SageX3TransactionInformation.FAILED:
+                    obj.retries += 1
                 for key, value in informations.items():
                     setattr(obj, key, value)
                 obj.save()

--- a/apps/billing/services/transaction_service.py
+++ b/apps/billing/services/transaction_service.py
@@ -83,6 +83,8 @@ class TransactionService:
 
     def run_steps_to_send_transaction(self):
         try:
+            log.info("Send transaction to SageX3 input_xml: %s", self.__processor.data)
+
             # save before sending
             self.__save_transaction_xml(
                 informations={
@@ -94,6 +96,7 @@ class TransactionService:
             )
 
             response = self.__processor.send_transaction_to_processor()
+            log.info("Receiving from SageX3 the response: %s", response)
 
             # save after sending
             self.__save_transaction_xml(

--- a/apps/billing/tests/test_transaction_processor_interface.py
+++ b/apps/billing/tests/test_transaction_processor_interface.py
@@ -1,0 +1,19 @@
+from django.test.testcases import TestCase
+
+from apps.billing.services.financial_processor_service import TransactionProcessorInterface
+
+class TransactionServiceTestCase(TestCase):
+    """
+    Tests the `TransactionService`
+    """
+
+    def test_financial_processor_service_interface(self):
+        """
+        This test ensures that if not implemented, the method from the interface
+        will raise an exception.
+        """
+        with self.assertRaisesMessage(
+            expected_exception=Exception,
+            expected_message="This method needs to be implemented",
+        ):
+            TransactionProcessorInterface(None).send_transaction_to_processor()

--- a/apps/billing/tests/test_transaction_processor_interface.py
+++ b/apps/billing/tests/test_transaction_processor_interface.py
@@ -2,6 +2,7 @@ from django.test.testcases import TestCase
 
 from apps.billing.services.financial_processor_service import TransactionProcessorInterface
 
+
 class TransactionServiceTestCase(TestCase):
     """
     Tests the `TransactionService`

--- a/apps/billing/tests/test_transaction_service.py
+++ b/apps/billing/tests/test_transaction_service.py
@@ -68,6 +68,8 @@ class TransactionServiceTestCase(TestCase):
         transaction_service = TransactionService(transaction=transaction)
         transaction_service.run_steps_to_send_transaction()
 
+        self.assertEqual(transaction.sage_x3_transaction_information.status, SageX3TransactionInformation.SUCCESS)
+
     @override_settings(TRANSACTION_PROCESSOR_URL="http://fake-processor.com")
     @mock.patch("requests.post", side_effect=raise_timeout)
     def test_transaction_to_processor_timeout_error_log(self, mocked_post):


### PR DESCRIPTION



feat: add log xml in and out
On transaction service logs the in and out xml to SageX3.
fixes fccn/nau-financial-manager#271

fix: if error to SageX3 save to error_messages
The error was being saved to output_xml.
The SageX3 output is saved to output_xml field.
The processing error is being saved to error_messages field.

test: input_xml in case of error
Test ensures that in case of error sending to processor we still have the input_xml value.

build: use pytest instead of django test
pytest has better output

test: if retries counter increases

fix: status not updating on success integration to Sage

refactor: split test

fix: save Transaction output_xml
The output_xml wasn't being saved.
Save input data xml before trying to sending and possibly crashing.

refactor: add memoization input xml to sage
Add memoization technique to save the data input xml that will be sent to Sage X3 Processor

refactor: transaction service