### PR TITLE
fix: SOAPAction HTTP header should be empty

### DIFF
--- a/apps/billing/services/processor_service.py
+++ b/apps/billing/services/processor_service.py
@@ -33,7 +33,7 @@ class SageX3Processor(TransactionProcessorInterface):
         response = requests.post(
             url=self.__processor_url,
             data=self.data,
-            headers={"Content-type": "application/xml", "SOAPAction": ""},
+            headers={"Content-type": "application/xml", "SOAPAction": "''"},
             auth=(
                 self.__user_processor_auth,
                 self.__user_processor_password,

--- a/apps/billing/tests/test_sagex3_processor_service.py
+++ b/apps/billing/tests/test_sagex3_processor_service.py
@@ -50,9 +50,9 @@ class SageX3ProcessServiceTest(TestCase):
     @mock.patch("apps.billing.services.processor_service.SageX3Processor.data", side_effect=lambda: {"some": "thing"})
     def test_send_transaction_to_processor_header_soapaction(self, mock_data, mock_post):
         """
-        Test the SOAPAction HTTP header sent to SageX3 is XML.
+        Test the SOAPAction HTTP header sent to SageX3 is XML, it should be an empty string.
         """
         SageX3Processor(None).send_transaction_to_processor()
         _, kwargs = mock_post.call_args
         called_headers = kwargs["headers"]
-        self.assertEqual("", called_headers["SOAPAction"])
+        self.assertEqual("''", called_headers["SOAPAction"])


### PR DESCRIPTION
The SOAPAction HTTP header require some value.
If empty string means that the intent of the SOAP
message is provided by the HTTP Request-URI.
relates to #273 and #276