### PR TITLE
Multiple changes

### DIFF
--- a/apps/billing/management/commands/retry_sage_transactions.py
+++ b/apps/billing/management/commands/retry_sage_transactions.py
@@ -30,8 +30,10 @@ class Command(BaseCommand):
             counters = {"success": 0, "failed": 0}
             try:
                 for sagex3_failed_transaction in sagex3_failed_transactions:
-                    TransactionService(sagex3_failed_transaction.transaction).run_steps_to_send_transaction()
-                    counters["success"] += 1
+                    if TransactionService(sagex3_failed_transaction.transaction).run_steps_to_send_transaction():
+                        counters["success"] += 1
+                    else:
+                        counters["failed"] += 1
             except Exception as e:
                 self.stdout.write(f"Error while retrying: {e}")
                 counters["failed"] += 1

--- a/apps/billing/models.py
+++ b/apps/billing/models.py
@@ -58,7 +58,7 @@ class Transaction(BaseModel):
     document_id = models.CharField(max_length=150, null=True, blank=True)
 
     def __str__(self):
-        return self.client_name
+        return self.transaction_id
 
 
 class TransactionItem(BaseModel):
@@ -97,7 +97,7 @@ class TransactionItem(BaseModel):
     )
 
     def __str__(self):
-        return self.description
+        return self.product_id
 
 
 class SageX3TransactionInformation(BaseModel):

--- a/apps/billing/services/transaction_service.py
+++ b/apps/billing/services/transaction_service.py
@@ -81,7 +81,11 @@ class TransactionService:
 
         return document_id
 
-    def run_steps_to_send_transaction(self):
+    def run_steps_to_send_transaction(self) -> bool:
+        """
+        Send the transaction to the SageX3,
+        returns a boolean indicating if the send has been run with success.
+        """
         try:
             log.info("Send transaction to SageX3 input_xml: %s", self.__processor.data)
 
@@ -112,6 +116,7 @@ class TransactionService:
             document_id = self.__class__.__extract_document_id_from_response(response)
             self.transaction.document_id = document_id
             self.transaction.save()
+            return True
         except Exception as e:
             # log the exception and eat it.
             log.exception(f"An exception has been raised when sending data to processor, exception message={e}")
@@ -123,3 +128,4 @@ class TransactionService:
                 },
                 transaction=self.transaction,
             )
+            return False

--- a/apps/billing/tests/test_transactions.py
+++ b/apps/billing/tests/test_transactions.py
@@ -21,8 +21,8 @@ class TransactionTest(TestCase):
         """
         Test the string representation of a Transaction instance.
         """
-        transaction = TransactionFactory(client_name="John Doe")
-        self.assertEqual(str(transaction), "John Doe")
+        transaction = TransactionFactory(transaction_id="A_LONG_HASH_ID")
+        self.assertEqual(str(transaction), "A_LONG_HASH_ID")
 
     def test_transaction_update(self):
         """
@@ -70,8 +70,10 @@ class TransactionItemTest(TestCase):
         """
         Test the string representation of a TransactionItem instance.
         """
-        transaction_item = TransactionItemFactory(description="Product A")
-        self.assertEqual(str(transaction_item), "Product A")
+        transaction_item = TransactionItemFactory(
+            product_id="Product_A",
+        )
+        self.assertEqual(str(transaction_item), "Product_A")
 
     def test_transaction_item_update(self):
         """

--- a/apps/organization/models.py
+++ b/apps/organization/models.py
@@ -18,4 +18,4 @@ class Organization(BaseModel):
         verbose_name_plural = _("Organizations")
 
     def __str__(self) -> str:
-        return f"{self.name}"
+        return f"{self.short_name}"

--- a/apps/organization/tests/test_organizations.py
+++ b/apps/organization/tests/test_organizations.py
@@ -48,8 +48,8 @@ class OrganizationModelTest(TestCase):
         """
         Test that the string representation of the organization is its name.
         """
-        expected_object_name = f"{self.organization.name}"
-        self.assertEqual(expected_object_name, str(self.organization))
+        expected_object_short_name = f"{self.organization.short_name}"
+        self.assertEqual(expected_object_short_name, str(self.organization))
 
     def test_create_organization(self):
         """


### PR DESCRIPTION
feat: improve admin for SageX3TransactionInformation
Improve the administration screen for the `SageX3TransactionInformation` object.
Add a simple filter by status.
Add a retry action.
fixes #281

fix: retry counters


refactor: add a return bool to send transaction service
Return a boolean with the success or not of sending the Transaction to the SageX3.
related to #280


fix: default model print shouldn't use nullable fields
The model classes shouldn't use nullable fields on the `__str__` function.
This makes the admin screens to raise an error and other problems
could be occur because of this problem.
relates to #280