### PR TITLE
fix: date issue for X3

### DIFF
--- a/apps/billing/services/processor_service.py
+++ b/apps/billing/services/processor_service.py
@@ -100,7 +100,7 @@ class SageX3Processor(TransactionProcessorInterface):
         items_as_xml = self.__generate_items_as_xml(items=items)
 
         transaction_id = transaction.transaction_id
-        transaction_date = str(transaction.transaction_date.date())
+        transaction_date = str(transaction.transaction_date.date().strftime("%Y%m%d"))
         vat_identification_country = getattr(transaction, "vat_identification_country", "")
         city = getattr(transaction, "city", "")
         country_code = getattr(transaction, "country_code", "")

--- a/apps/billing/tests/test_sagex3_processor_data.py
+++ b/apps/billing/tests/test_sagex3_processor_data.py
@@ -38,7 +38,7 @@ class SageX3ProcessDataTest(TestCase):
         object_xml_root: ET.Element = self.__class__._get_xml_element_from_transaction(
             TransactionFactory(transaction_date=transaction_date)
         )
-        self.assertEqual(object_xml_root.findtext(".//*/FLD[@NAME='INVDAT']"), transaction_date.strftime("%Y-%m-%d"))
+        self.assertEqual(object_xml_root.findtext(".//*/FLD[@NAME='INVDAT']"), transaction_date.strftime("%Y%m%d"))
 
     @override_settings(GEOGRAPHIC_ACTIVITY_VACBPR_FIELD="XPTO")
     def test_data_processor_geographic_activity_override(self):


### PR DESCRIPTION
The field INVDAT for the Sage X3 should use the date format: YYYYMMDD instead of YYYY-MM-DD.
fixes #295