### PR TITLE
feat: add document_type on iLink integration

### DIFF
--- a/apps/billing/services/receipt_host_service.py
+++ b/apps/billing/services/receipt_host_service.py
@@ -25,7 +25,7 @@ class ReceiptDocumentHost:
         """
         response = requests.get(
             url=f"{self.__receipt_host_url}",
-            params={"document_number": document_id},
+            params={"document_number": document_id, "document_type": "issued"},
             headers={
                 "entity": self.__receipt_entity_public_key,
                 "Authorization": f"Bearer {self.__receipt_bearer_token}",


### PR DESCRIPTION
Add the fixed `document_type` parameter with value of `issued`
when querying iLink, so we can search documents issued by
fixes #299

----


test: receipt host service

Replace `ReceiptDocumentHostForTest` with a override settings configuration.
Improve success test with asserts on iLink GET.