### PR TITLE
Revert simplify get document output

### DIFF
--- a/apps/billing/views.py
+++ b/apps/billing/views.py
@@ -55,14 +55,14 @@ def get_receipt_link(request, *args, **kwargs):
         transaction = Transaction.objects.get(transaction_id=kwargs["transaction_id"])
         receipt_link = ReceiptDocumentHost().get_document(document_id=transaction.document_id)
 
-        return Response(receipt_link, status=200)
+        return Response({"response": receipt_link}, status=200)
     except requests.exceptions.RequestException as e:
         if e.response.status_code == 404:
-            return Response("File not found", status=404)
+            return Response({"response": "File not found"}, status=404)
 
-        return Response("Occurred an error getting the document", status=500)
+        return Response({"response": "Occurred an error getting the document"}, status=500)
     except ObjectDoesNotExist:
-        return Response("Transaction not found", status=404)
+        return Response({"response": "Transaction not found"}, status=404)
     except Exception:
         log.exception("Not expected error ocurred getting the document")
-        return Response("A not expected error ocurred getting the document", status=500)
+        return Response({"response": "A not expected error ocurred getting the document"}, status=500)

--- a/apps/billing/views.py
+++ b/apps/billing/views.py
@@ -47,6 +47,13 @@ def get_receipt_link(request, *args, **kwargs):
     meaning that the client should send the `Authorization` HTTP header with a value of `Token`
     string plus the value of the token, example:
         Authorization: Token 401f7ac837da42b97f613d789819ff93537bee6a
+
+    Returns a Json with a response.
+    - 200
+    {"response": "https://ilink.acin.pt/ilinktests-api/file/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}
+    - 404 - if transaction isn't found or the file is missing on iLink
+    - 400 - if transaction if isn't found
+    - 500 - if error getting document
     """
 
     try:


### PR DESCRIPTION
- revert: simplify get document output

Rest framework requires json output, if not the output will have the character `"`.

- refactor: use rest vars
- docs: add better doc on get receipt link

