### PR TITLE
fix(x3): content type missing charset

### DIFF
--- a/apps/billing/services/processor_service.py
+++ b/apps/billing/services/processor_service.py
@@ -47,7 +47,7 @@ class SageX3Processor(TransactionProcessorInterface):
         response = requests.post(
             url=self.__processor_url,
             data=self.data,
-            headers={"Content-type": "application/xml; charset=utf-8", "SOAPAction": "''"},
+            headers={"Content-type": "text/xml; charset=UTF-8", "SOAPAction": "''"},
             auth=(
                 self.__user_processor_auth,
                 self.__user_processor_password,

--- a/apps/billing/tests/test_sagex3_processor_service.py
+++ b/apps/billing/tests/test_sagex3_processor_service.py
@@ -44,7 +44,7 @@ class SageX3ProcessServiceTest(TestCase):
         SageX3Processor(None).send_transaction_to_processor()
         _, kwargs = mock_post.call_args
         called_headers = kwargs["headers"]
-        self.assertEqual("application/xml; charset=utf-8", called_headers["Content-type"])
+        self.assertEqual("text/xml; charset=UTF-8", called_headers["Content-type"])
 
     @mock.patch("requests.post", return_value=MockResponse(data="", status_code=200))
     @mock.patch("apps.billing.services.processor_service.SageX3Processor.data", side_effect=lambda: {"some": "thing"})


### PR DESCRIPTION
Fix missing charset on Content Type HTTP header when integrating to Sage X3.

fix #309