### PR TITLE
fix(x3): country name `YCRYNAM` field

### DIFF
--- a/apps/billing/services/processor_service.py
+++ b/apps/billing/services/processor_service.py
@@ -2,6 +2,7 @@ import xml.etree.ElementTree as ET
 
 import requests
 from django.conf import settings
+from django.utils import translation
 
 from apps.billing.models import Transaction, TransactionItem
 from apps.billing.services.financial_processor_service import TransactionProcessorInterface
@@ -104,7 +105,9 @@ class SageX3Processor(TransactionProcessorInterface):
         transaction_date = str(transaction.transaction_date.date().strftime("%Y%m%d"))
         vat_identification_country = getattr(transaction, "vat_identification_country", "")
         city = getattr(transaction, "city", "")
-        country_code = getattr(transaction, "country_code", "")
+        with translation.override("PT"):  # We have to send the Country name in Portuguese
+            country_code = getattr(transaction, "country_code")
+            country_name = country_code.name if country_code else ""
         postal_code = transaction.postal_code
         postal_code = postal_code.replace("-", "").replace(" ", "") if postal_code else ""
         vat_identification_number = str(transaction.vat_identification_number or "")
@@ -137,7 +140,7 @@ class SageX3Processor(TransactionProcessorInterface):
                 </GRP>
                 <GRP ID="YIL_2">
                     <FLD NAME="YCRY" TYPE="Char">{vat_identification_country}</FLD>
-                    <FLD NAME="YCRYNAM" TYPE="Char">{country_code}</FLD>
+                    <FLD NAME="YCRYNAM" TYPE="Char">{country_name}</FLD>
                     <FLD NAME="YPOSCOD" TYPE="Char">{postal_code}</FLD>
                     <FLD NAME="YCTY" TYPE="Char">{city}</FLD>
                     <FLD NAME="YBPIEECNUM" TYPE="Char">{vat_identification_country}{vat_identification_number}</FLD>

--- a/apps/billing/tests/test_sagex3_processor_data.py
+++ b/apps/billing/tests/test_sagex3_processor_data.py
@@ -87,9 +87,10 @@ class SageX3ProcessDataTest(TestCase):
         )
         self.assertEqual(object_xml_root.findtext(".//*/FLD[@NAME='YCRY']"), "PT")
 
-    def test_data_processor_vat_identification_country_portugal_alpha3(self):
+    def test_data_processor_vat_identification_country_portugal_alpha2(self):
         """
-        Test the SageX3Processor for vat identification country field for portugal
+        Test the SageX3Processor for vat identification country field for Portugal
+        is using the correct format of 2 digits to represent the country.
         """
         object_xml_root: ET.Element = self.__class__._get_xml_element_from_transaction(
             TransactionFactory(vat_identification_country="PRT")
@@ -112,16 +113,16 @@ class SageX3ProcessDataTest(TestCase):
         object_xml_root: ET.Element = self.__class__._get_xml_element_from_transaction(
             TransactionFactory(country_code="PT")
         )
-        self.assertEqual(object_xml_root.findtext(".//*/FLD[@NAME='YCRYNAM']"), "PT")
+        self.assertEqual(object_xml_root.findtext(".//*/FLD[@NAME='YCRYNAM']"), "Portugal")
 
-    def test_data_processor_country_code_great_britain_alpha3(self):
+    def test_data_processor_country_code_great_britain_in_portuguese(self):
         """
         Test the SageX3Processor for country code field.
         """
         object_xml_root: ET.Element = self.__class__._get_xml_element_from_transaction(
             TransactionFactory(country_code="GBR")
         )
-        self.assertEqual(object_xml_root.findtext(".//*/FLD[@NAME='YCRYNAM']"), "GB")
+        self.assertEqual(object_xml_root.findtext(".//*/FLD[@NAME='YCRYNAM']"), "Reino Unido")
 
     def test_data_processor_country_code_none(self):
         """


### PR DESCRIPTION
The country name on field `YCRYNAM` on the XML sent to SageX3 was using the country alpha2 code instead of sending the name in portuguese.

fixes: #312