### PR TITLE
feat: removed prices without vat tax from API

### DIFF
--- a/apps/billing/views.py
+++ b/apps/billing/views.py
@@ -10,7 +10,7 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 
 from apps.billing.models import Transaction
-from apps.billing.serializers import ProcessTransactionSerializer
+from apps.billing.serializers import ProcessTransactionSerializerForAPI
 from apps.billing.services.receipt_host_service import ReceiptDocumentHost
 from apps.util.base_views import GeneralPost
 
@@ -31,7 +31,7 @@ class ProcessTransaction(APIView, GeneralPost):
     """
 
     authentication_classes = [TokenAuthentication]
-    serializer = ProcessTransactionSerializer
+    serializer = ProcessTransactionSerializerForAPI
     permission_classes = [IsAuthenticated]
 
 

--- a/nau_financial_manager/settings.py
+++ b/nau_financial_manager/settings.py
@@ -287,6 +287,9 @@ SWAGGER_PROJECT_NAME = CONFIG.get("SWAGGER_PROJECT_NAME", "Nau Financial Manager
 SWAGGER_PROJECT_VERSION = CONFIG.get("SWAGGER_PROJECT_VERSION", "1.0.0")
 SWAGGER_DESCRIPTION = CONFIG.get("SWAGGER_DESCRIPTION", "API for Nau Financial Manager")
 
+# VAT / IVA
+VAT_TAX_RATE = CONFIG.get("VAT_TAX_RATE", 0.23)
+
 # Add a way to use Token authentication on the Swagger UI
 SWAGGER_SETTINGS = {
     "SECURITY_DEFINITIONS": {"api_key": {"type": "apiKey", "in": "header", "name": "Authorization"}},


### PR DESCRIPTION
Added a new `VAT_TAX_RATE` setting.
The excluding vat tax fields were removed from API, but they are calculated dynamic using the `VAT_TAX_RATE` setting.

related to fccn/nau-technical#215