### PR TITLE
Do not send basket with seat with full discount to Sage X3

### DIFF
--- a/apps/billing/serializers.py
+++ b/apps/billing/serializers.py
@@ -167,7 +167,8 @@ class ProcessTransactionSerializerForAPI(CountryFieldMixin, serializers.ModelSer
                 product_id=item.product_id,
             )
 
-        create_and_async_send_transactions_to_processor_task(transaction=transaction)
+        if not float(transaction.total_amount_include_vat) == 0:
+            create_and_async_send_transactions_to_processor_task(transaction=transaction)
 
         return validated_data
 


### PR DESCRIPTION
This PR makes a refactor to not send to `SageX3` transactions that have 0 as total amount. That is, the transaction needs to be saved, but not generated from a receipt, as nothing was sold.