### PR TITLE
fix: changed sage response message handling

### DIFF
--- a/apps/billing/mocks.py
+++ b/apps/billing/mocks.py
@@ -622,7 +622,7 @@ def xml_duplicate_error_response_mock():
                 </wss:saveResponse>
                 <multiRef id="id0" soapenc:root="0" soapenv:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" xsi:type="wss:CAdxMessage">
                     <type>3</type>
-                    <message>Nº Fatura NAU já registada no documento: {settings.DEFAULT_SERIES}-{randint(21, 23)}/000{randint(10, 64)}</message>
+                    <message>A Referência OPENEDX-{randint(100000, 999999)} já registada no Nº Fatura NAU : {settings.DEFAULT_SERIES}-{randint(21, 26)}/000{randint(10, 64)}</message>
                 </multiRef>
             </soapenv:Body>
             </soapenv:Envelope>

--- a/apps/billing/services/processor_service.py
+++ b/apps/billing/services/processor_service.py
@@ -9,7 +9,6 @@ from apps.billing.services.financial_processor_service import TransactionProcess
 
 
 class SageX3Processor(TransactionProcessorInterface):
-
     ENCODING = "utf-8"
 
     """

--- a/apps/billing/services/transaction_service.py
+++ b/apps/billing/services/transaction_service.py
@@ -63,9 +63,9 @@ class TransactionService:
         response_as_json = response_as_json["soapenv:Envelope"]["soapenv:Body"]
 
         if "multiRef" in list(dict(response_as_json).keys()):
-            message = "Nº Fatura NAU já registada no documento: "
-            if message in response_as_json["multiRef"]["message"]:
-                document_id = response_as_json["multiRef"]["message"].replace(message, "")
+            expected_message = "já registada no Nº Fatura NAU : "
+            if expected_message in response_as_json["multiRef"]["message"]:
+                document_id = response_as_json["multiRef"]["message"].split(":")[-1].strip()
 
                 return document_id
 
@@ -74,7 +74,7 @@ class TransactionService:
         for r in result["RESULT"]["GRP"]:
             for field in r["FLD"]:
                 if field["@NAME"] == "NUM":
-                    document_id = field["#text"]
+                    document_id = field.get("#text")
                     break
 
             if document_id:

--- a/apps/billing/tests/test_transaction_service.py
+++ b/apps/billing/tests/test_transaction_service.py
@@ -416,6 +416,8 @@ class TransactionServiceTestCase(TestCase):
         self.assertEqual(len(transaction_information), 1)
         self.assertEqual(transaction_information[0].transaction.transaction_id, transaction.transaction_id)
         self.assertEqual(transaction_information[0].status, SageX3TransactionInformation.FAILED)
+        document_id = transaction_information[0].transaction.document_id
+        self.assertTrue(document_id.startswith("AAA-"))
 
         self.assertTrue(isinstance(counters, dict))
         self.assertEqual(counters["total_count"], 1)


### PR DESCRIPTION
The message for a duplicate invoice from sage changed.

The code was adapted to receive the new message.

Related to:
fccn/nau-technical#767