### PR TITLE
fix: city default value

### DIFF
--- a/apps/billing/services/processor_service.py
+++ b/apps/billing/services/processor_service.py
@@ -107,7 +107,7 @@ class SageX3Processor(TransactionProcessorInterface):
         transaction_id = transaction.transaction_id
         transaction_date = str(transaction.transaction_date.date().strftime("%Y%m%d"))
         vat_identification_country = getattr(transaction, "vat_identification_country", "")
-        city = getattr(transaction, "city", "")
+        city = str(transaction.city or "")
         with translation.override("PT"):  # We have to send the Country name in Portuguese
             country_code = getattr(transaction, "country_code")
             country_name = country_code.name if country_code else ""

--- a/apps/billing/tests/test_sagex3_processor_data.py
+++ b/apps/billing/tests/test_sagex3_processor_data.py
@@ -160,6 +160,18 @@ class SageX3ProcessDataTest(TestCase):
         )
         self.assertEqual(object_xml_root.find(".//*/FLD[@NAME='YPOSCOD']").text, None)
 
+    def test_data_processor_city_none_sends_empty_string(self):
+        """
+        When the transaction city is None it should send an empty string in the XML.
+        """
+        transaction = TransactionFactory(city=None)
+        xml = SageX3Processor(transaction).data
+        root = ET.fromstring(xml)  # nosec
+        object_xml: str = root.findall(".//*/objectXml")[0].text.strip()
+
+        # Expect an explicit empty element body for the city field
+        self.assertIn('<FLD NAME="YCTY" TYPE="Char"></FLD>', object_xml)
+
     def test_data_processor_vat_identification_number_corporate(self):
         """
         Test the SageX3Processor for country code field.


### PR DESCRIPTION
When city is not defined then it should send an empty string on the XML to Sage X3.

fccn/nau-technical#767