### PR TITLE
fix: set default values for client name and address line 1

### DIFF
--- a/apps/billing/services/processor_service.py
+++ b/apps/billing/services/processor_service.py
@@ -116,8 +116,8 @@ class SageX3Processor(TransactionProcessorInterface):
         vat_identification_number = str(transaction.vat_identification_number or "")
         email = str(transaction.email or "")
         transaction_type = str(transaction.transaction_type or "")
-        client_name = str(transaction.client_name or "")
-        address_line_1 = str(transaction.address_line_1 or "")
+        client_name = str(transaction.client_name or "Consumidor Final")
+        address_line_1 = str(transaction.address_line_1 or "Não Definido")
         address_line_2 = str(transaction.address_line_2 or "")
 
         objectXML = f"""

--- a/apps/billing/tests/test_sagex3_processor_data.py
+++ b/apps/billing/tests/test_sagex3_processor_data.py
@@ -246,7 +246,7 @@ class SageX3ProcessDataTest(TestCase):
         object_xml_root: ET.Element = self.__class__._get_xml_element_from_transaction(
             TransactionFactory(client_name=None)
         )
-        self.assertEqual(object_xml_root.find(".//*/LST[@NAME='YBPRNAM']/ITM").text, None)
+        self.assertEqual(object_xml_root.find(".//*/LST[@NAME='YBPRNAM']/ITM").text, "Consumidor Final")
 
     def test_data_processor_address_line_1(self):
         """
@@ -264,7 +264,7 @@ class SageX3ProcessDataTest(TestCase):
         object_xml_root: ET.Element = self.__class__._get_xml_element_from_transaction(
             TransactionFactory(address_line_1=None)
         )
-        self.assertEqual(object_xml_root.find(".//*/LST[@NAME='YBPAADDLIG']/ITM").text, None)
+        self.assertEqual(object_xml_root.find(".//*/LST[@NAME='YBPAADDLIG']/ITM").text, "Não Definido")
 
     def test_data_processor_address_line_2(self):
         """


### PR DESCRIPTION
In SageX3Processor integration define a default values required by SageX3 to process the receipt.

fccn/nau-technical#767